### PR TITLE
【課題17】ApacheCommonLang3.14.0を追加、StringUtilsを試行

### DIFF
--- a/HelloWorldGroovy/build.gradle
+++ b/HelloWorldGroovy/build.gradle
@@ -18,6 +18,8 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	// Apache　Common　Lang3.14.0を追加
+	implementation 'org.apache.commons:commons-lang3:3.14.0'
 	providedRuntime 'org.springframework.boot:spring-boot-starter-tomcat'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/HelloWorldGroovy/src/main/java/chapter17/groovy/HelloWorldGroovy/HelloWorldGroovyApplication.java
+++ b/HelloWorldGroovy/src/main/java/chapter17/groovy/HelloWorldGroovy/HelloWorldGroovyApplication.java
@@ -1,5 +1,7 @@
 package chapter17.groovy.HelloWorldGroovy;
 
+import java.util.List;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -18,4 +20,13 @@ public class HelloWorldGroovyApplication {
     return "Hello, World!";
   }
 
+  @GetMapping("/numeric")
+  // StringUtilsを試しに使用する。
+  public String showBoolean() {
+    String result1 = String.valueOf(StringUtils.isNumeric("sushi"));
+    String result2 = String.valueOf(StringUtils.isNumeric("すし"));
+    String result3 = String.valueOf(StringUtils.isNumeric("123"));
+    String result = "数字かどうか判定します。「sushi」は" + result1 + ", 「すし」は" + result2 + ", 「123」は" + result3 +"です。";
+    return result;
+  }
 }


### PR DESCRIPTION
**新カリキュラム第17回の課題（プロジェクトの構成管理_Gradle_Maven）を、以下のとおりで実施いたしましたので、ご確認をお願いいたします。**

※第15回の動画で説明のあった、Hello, world!を表示するアプリケーションをメインブランチにプッシュしたうえで、本PRを行っています。
***

## 概要
**◆build.gradleのdependenciesに、'org.apache.commons:commons-lang3:3.14.0'を追加しました**
**◆HelloWorldGroovyApplication.javaに、StringUtils.isNumericを使用した簡単なメソッドを追加し、ドメインで表示できるようにしました。**
***
   
## 動作確認
**◆HelloWorldGroovyApplication.javaを実行し、ブラウザにlocalhost:8080/numericを入力すると、以下のように出力されます。**
![動作確認](https://github.com/YaraiM/JavaNewChapter17Assignment/assets/153747182/07524101-e4ec-4972-9f0b-e31256f470f5)

***
**【補足】MavenでもSpringBootのプロジェクトを作成し、Gradleのプロジェクト構成管理と比較しました。**

**Gradleのプロジェクト構成管理（build.gradle）**
![プロジェクト居構成管理差分_build gradle](https://github.com/YaraiM/JavaNewChapter17Assignment/assets/153747182/a17802d8-2776-4ccd-a166-69a8aafdc4ef)

**Mavenのプロジェクト構成管理（pom.xml）**

![プロジェクト居構成管理差分_pom xml](https://github.com/YaraiM/JavaNewChapter17Assignment/assets/153747182/4f3a6d08-61ee-4cfc-a7b3-40b69c7c81d0)
![プロジェクト居構成管理差分2_pom xml](https://github.com/YaraiM/JavaNewChapter17Assignment/assets/153747182/c1769d6f-1f23-4ffd-bacd-c329513c9d62)

例えばdependenciesの部分を比較すると、build.gradleの方ではgroupIDとartificialIDが1行で表現されているのに対し、pom.xmlの方ではそれぞれが1行ずつ表現されています。前者の方がコードがすっきりしていますが、後者の方が情報が明確・詳細に記載されているように思いました。